### PR TITLE
Add package command to cleo application

### DIFF
--- a/masonite_cli/application.py
+++ b/masonite_cli/application.py
@@ -6,10 +6,12 @@ from .helpers.helpers import add_venv_site_packages
 
 from .commands.NewCommand import NewCommand
 from .commands.InstallCommand import InstallCommand
+from .commands.PackageCommand import PackageCommand
 
-application = Application('Craft Version:', '2.0.0')
+application = Application('Craft Version:', '2.0.1')
 application.add(NewCommand())
 application.add(InstallCommand())
+application.add(PackageCommand())
 
 
 ERROR = None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="masonite-cli",
-    version='2.0.0',
+    version='2.0.1',
     packages=[
         'masonite_cli',
         'masonite_cli.commands',


### PR DESCRIPTION
Going through the [documentation](https://docs.masoniteproject.com/advanced/creating-packages), readers come across the `craft package` command. In the current version of `craft`, the package command is omitted.

This pull request adds the `PackageCommand` to the cleo application and bumps the version.