### PR TITLE
remove craft.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 venv
-craft.egg-info
 masonite_cli.egg-info
 .vscode
 dist


### PR DESCRIPTION
`pip install -e .` will generate `masonite_cli.egg-info` which is already in `.gitignore`