### PR TITLE
install: do not overwrite .env if exists

### DIFF
--- a/masonite_cli/commands/InstallCommand.py
+++ b/masonite_cli/commands/InstallCommand.py
@@ -11,7 +11,7 @@ class InstallCommand(Command):
     install
         {--no-key : If set, craft install command will not generate and store a new key}
         {--no-dev : If set, Masonite will install with dev dependencies}
-        {--f|--force=False : Overwrite .env if exists}
+        {--f|--force : Overwrite .env if exists}
     """
 
     def handle(self):

--- a/masonite_cli/commands/InstallCommand.py
+++ b/masonite_cli/commands/InstallCommand.py
@@ -11,11 +11,13 @@ class InstallCommand(Command):
     install
         {--no-key : If set, craft install command will not generate and store a new key}
         {--no-dev : If set, Masonite will install with dev dependencies}
+        {--f|--force=False : Overwrite .env if exists}
     """
 
     def handle(self):
 
-        shutil.copy('.env-example', '.env')
+        if not os.path.isfile('.env') or self.option('force'):
+            shutil.copy('.env-example', '.env')
 
         if os.path.isfile('Pipfile'):
             try:


### PR DESCRIPTION
Prevent an unexpected overwrite of .env